### PR TITLE
Log response body if CRM push is unsuccessful

### DIFF
--- a/lib/solidus_crm/connection.rb
+++ b/lib/solidus_crm/connection.rb
@@ -54,6 +54,7 @@ module SolidusCrm
         Rails.logger.info('CRM notification successful')
       else
         Rails.logger.info("Bad response from CRM, got #{response.code} not 200")
+        Rails.logger.info("Response body was: #{response.body}")
       end
     end
   end


### PR DESCRIPTION
### What:
Log out the response body when the response to a CRM notification is anything other than successful.

### Why:
A small percentage of CRM notifications are failing with 500 errors when sent to Santa Maria, and since NL relies on these notifications to fulfil orders, the ones that fail can be lost at this point. This PR should help us determine whether or not there's an issue with the payload we're sending.